### PR TITLE
Fix viewport meta tag typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <script src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/16327/gsap-latest-beta.min.js"></script>
     <script src="https://codepen.io/carolineartz/pen/abzLQoQ"></script>
     <!--is supposted to set up the correct scale but doesnt work-->
-    <meta name="viewport" content="width=device-width, intitial-scal=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!--gives a description to the website-->
     <meta name="description" content="Elijah Raffel / Linkedin Email Github" />
     <!--Puts the name at the top of the file-->


### PR DESCRIPTION
## Summary
- fix typo in viewport meta tag for proper mobile scaling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687037c6994c832ab993592f5cdf2bdd